### PR TITLE
Tailwind uses uppercase DEFAULT now

### DIFF
--- a/index.js
+++ b/index.js
@@ -174,7 +174,7 @@ module.exports = function ({ addUtilities, config, e, theme, variants }) {
   const utilities = {}
 
   for (const [fontFamily, capHeightFraction] of fontCapHeights) {
-    const fontFamilySelector = fontFamily === 'default'
+    const fontFamilySelector = fontFamily.toLowerCase() === 'default'
       ? ''
       : e(fontFamily.replace(/\s+/, '-').toLowerCase())
 


### PR DESCRIPTION
Changed code to do a lowercase compare so old and new tailwind users will both work.

Docu reference to new DEFAULT: https://tailwindcss.com/docs/upgrading-to-v2#update-default-theme-keys-to-default